### PR TITLE
fix: replace ids with usernames in MessageEmbed

### DIFF
--- a/source/karma.js
+++ b/source/karma.js
@@ -102,7 +102,7 @@ const karma = bot => {
       const embed = new MessageEmbed()
         .setColor('#C580F2')
         .setAuthor('Pumpkin from Scrimba', bot.user.displayAvatarURL())
-        .setDescription(`Well done <@${message.author.id}>! <@${user.id}> reacted to your post [post](https://discord.com/channels/684009642984341525/${message.channel.id}/${message.id}) in <#${message.channel.id}> with 💜 which earned you a point.
+        .setDescription(`Well done <@${message.author.username}>! <@${user.username}> reacted to your post [post](https://discord.com/channels/684009642984341525/${message.channel.id}/${message.id}) in <#${message.channel.id}> with 💜 which earned you a point.
 
 You now have ${count} karma! To see your karma anytime type \`/karma\``)
 


### PR DESCRIPTION
resolves #15 

`author` is of type `User`
https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=author
and `User` has `username`string property
https://discord.js.org/#/docs/main/stable/class/User?scrollTo=username